### PR TITLE
Move destination for SAP Build Apps VCF from space to subaccount

### DIFF
--- a/released/modules/sap_build_apps/standard/main.tf
+++ b/released/modules/sap_build_apps/standard/main.tf
@@ -117,13 +117,14 @@ resource "btp_subaccount_role_collection_assignment" "build_apps_RegistryDevelop
 ###############################################################################################
 # Create destination for Visual Cloud Functions
 ###############################################################################################
-# Get destnation service plan
+# Get plan for destination service
 data "btp_subaccount_service_plan" "by_name" {
   subaccount_id = var.subaccount_id
   name          = "lite"
   offering_name = "destination"
 } 
-# Get subaccount
+
+# Get subaccount data
 data "btp_subaccount" "subaccount" {
   id = var.subaccount_id
 }
@@ -131,7 +132,6 @@ data "btp_subaccount" "subaccount" {
 # Create the destination
 resource "btp_subaccount_service_instance" "vcf_destination" {
   subaccount_id  = var.subaccount_id
-  # The service plan ID can be looked up via the data source btp_subaccount_service_plan
   serviceplan_id =  data.btp_subaccount_service_plan.by_name.id
   name           = "SAP-Build-Apps-Runtime"
   parameters = jsonencode({

--- a/released/modules/sap_build_apps/standard/main.tf
+++ b/released/modules/sap_build_apps/standard/main.tf
@@ -114,3 +114,43 @@ resource "btp_subaccount_role_collection_assignment" "build_apps_RegistryDevelop
       user_name            = each.value
       origin               = var.custom_idp_origin
 }
+###############################################################################################
+# Create destination for Visual Cloud Functions
+###############################################################################################
+# Get destnation service plan
+data "btp_subaccount_service_plan" "by_name" {
+  subaccount_id = var.subaccount_id
+  name          = "lite"
+  offering_name = "destination"
+} 
+# Get subaccount
+data "btp_subaccount" "subaccount" {
+  id = var.subaccount_id
+}
+
+# Create the destination
+resource "btp_subaccount_service_instance" "vcf_destination" {
+  subaccount_id  = var.subaccount_id
+  # The service plan ID can be looked up via the data source btp_subaccount_service_plan
+  serviceplan_id =  data.btp_subaccount_service_plan.by_name.id
+  name           = "SAP-Build-Apps-Runtime"
+  parameters = jsonencode({
+    HTML5Runtime_enabled = true
+    init_data = {
+      subaccount = {
+        existing_destinations_policy = "update"
+        destinations = [
+          {
+            Name = "SAP-Build-Apps-Runtime"
+            Type = "HTTP"
+            Description = "Endpoint to SAP Build Apps runtime"
+            URL = "https://${data.btp_subaccount.subaccount.subdomain}.cr1.${data.btp_subaccount.subaccount.region}.apps.build.cloud.sap/"
+            ProxyType = "Internet"
+            Authentication = "NoAuthentication"
+            "HTML5.ForwardAuthToken" = true
+          }
+        ]
+      }
+    }
+  })
+}

--- a/released/uc_sap_build_apps/main.tf
+++ b/released/uc_sap_build_apps/main.tf
@@ -116,30 +116,3 @@ module "cloudfoundry_space" {
   cf_space_developers = var.cf_space_developers
   cf_space_auditors   = var.cf_space_auditors
 }
-
-module "setup_cf_service_destination" {
-  depends_on          = [module.cloudfoundry_space]
-  source              = "../modules/cloudfoundry-service-instance/"
-  cf_space_id         = module.cloudfoundry_space.id
-  service_name        = "destination"
-  plan_name           = "lite"
-  parameters = jsonencode({
-    HTML5Runtime_enabled = true
-    init_data = {
-      subaccount = {
-        existing_destinations_policy = "update"
-        destinations = [
-          {
-            Name = "SAP-Build-Apps-Runtime"
-            Type = "HTTP"
-            Description = "Endpoint to SAP Build Apps runtime"
-            URL = "https://${module.cloudfoundry_environment.org_name}.cr1.${var.region}.apps.build.cloud.sap/"
-            ProxyType = "Internet"
-            Authentication = "NoAuthentication"
-            "HTML5.ForwardAuthToken" = true
-          }
-        ]
-      }
-    }
-  })
-}


### PR DESCRIPTION
# Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...
The Destination for the connection between SAP Build Apps and Visual Cloud Functions should be on the subaccount level not on the space level. Also the  destination creation should be in the module and not in the calling script.
## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "x". -->
move destination configuration from us_cap_build_apps to  sap_build_apps module
```
[ ] Bugfix
[ ] Feature
[ ] Documentation content changes
[ x] Other... Please describe: Improvement for SAP Build Apps 
```
## Other Information
<!-- Add any other helpful information that may be needed here. -->
