### PR TITLE
feat: module for kyma

### DIFF
--- a/released/modules/envinstance-kyma/README.md
+++ b/released/modules/envinstance-kyma/README.md
@@ -1,0 +1,49 @@
+# Terraform BTP Kyma Runtime Module
+
+This Terraform module is used to create and manage a Kyma Runtime in a BTP (Business Technology Platform) subaccount.
+
+## Usage
+
+```hcl
+module "kyma_runtime" {
+  source        = "github.com/SAP-samples/released/modules/envinstance-kyma"
+  subaccount_id = "your-subaccount-id"
+  name          = "kyma-cluster-name"
+  administrators = ["user1@example.com", "user2@example.com"]
+}
+```
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| btp  | n/a     |
+
+## Inputs
+
+| Name            | Description                                                                    | Type           | Default | Required |
+|-----------------|--------------------------------------------------------------------------------|----------------|---------|:--------:|
+| subaccount_id   | The ID of the subaccount.                                                      | `string`       | n/a     | yes      |
+| plan            | The kyma service plan to be used.                                              | `string`       | `null`  | no       |
+| name            | The name of the kyma cluster.                                                  | `string`       | n/a     | yes      |
+| administrators  | Users to be assigned as administrators.                                        | `set(string)`  | `[]`    | no       |
+| oidc            | Custom OpenID Connect IdP to authenticate users in your Kyma runtime.          | `object`       | `null`  | no       |
+| region          | The region of the kyma environment.                                            | `string`       | `"eu12"`| no       |
+
+## Outputs
+
+| Name           | Description                       |
+|----------------|-----------------------------------|
+| dashboard_url  | The URL of the Kyma dashboard.    |
+| kubeconfig     | The filename of the kubeconfig.   |
+
+## OIDC Object
+
+| Field           | Description   |
+|-----------------|---------------|
+| issuer_url      | The URL of the OpenID issuer (use the https schema). |
+| client_id       | The client ID for the OpenID client. |
+| groups_claim    | The name of a custom OpenID Connect claim for specifying user groups. |
+| signing_algs    | The list of allowed cryptographic algorithms used for token signing. The allowed values are defined by RFC 7518. |
+| username_prefix | The prefix for all usernames. If you don't provide it, username claims other than “email” are prefixed by the issuerURL to avoid clashes. To skip any prefixing, provide the value as -. |
+| username_claim  | The name of a custom OpenID Connect claim for specifying a username. |

--- a/released/modules/envinstance-kyma/main.tf
+++ b/released/modules/envinstance-kyma/main.tf
@@ -1,0 +1,51 @@
+locals {
+  subaccount_iaas_provider = [for region in data.btp_regions.all.values : region if region.region == data.btp_subaccount.this.region][0].iaas_provider
+}
+
+data "btp_regions" "all" {}
+
+data "btp_subaccount" "this" {
+  id = var.subaccount_id
+}
+
+resource "btp_subaccount_entitlement" "kymaruntime" {
+  subaccount_id = var.subaccount_id
+
+  service_name = "kymaruntime"
+  plan_name    = var.plan != null ? var.plan : lower(local.subaccount_iaas_provider)
+  amount       = 1
+}
+
+data "btp_whoami" "me" {}
+
+resource "btp_subaccount_environment_instance" "kymaruntime" {
+  subaccount_id = var.subaccount_id
+
+  name             = var.name
+  environment_type = "kyma"
+  service_name     = btp_subaccount_entitlement.kymaruntime.service_name
+  plan_name        = btp_subaccount_entitlement.kymaruntime.plan_name
+
+  parameters = jsonencode(merge({
+    name           = var.name
+    administrators = toset(concat(tolist(var.administrators), [data.btp_whoami.me.email]))
+    }, var.oidc == null ? null : {
+    issuerURL      = var.oidc.issuer_url
+    clientID       = var.oidc.client_id
+    groupsClaim    = var.oidc.groups_claim
+    usernameClaim  = var.oidc.username_claim
+    usernamePrefix = var.oidc.username_prefix
+    signingAlgs    = var.oidc.signing_algs
+  }))
+
+  depends_on = [btp_subaccount_entitlement.kymaruntime]
+}
+
+data "http" "kubeconfig" {
+  url = jsondecode(btp_subaccount_environment_instance.kymaruntime.labels)["KubeconfigURL"]
+}
+
+resource "local_sensitive_file" "kubeconfig" {
+  filename = ".${var.subaccount_id}-${var.name}.kubeconfig"
+  content  = data.http.kubeconfig.response_body
+}

--- a/released/modules/envinstance-kyma/outputs.tf
+++ b/released/modules/envinstance-kyma/outputs.tf
@@ -1,0 +1,7 @@
+output "dashboard_url" {
+  value = btp_subaccount_environment_instance.kymaruntime.dashboard_url
+}
+
+output "kubeconfig" {
+  value = local_sensitive_file.kubeconfig.filename
+}

--- a/released/modules/envinstance-kyma/provider.tf
+++ b/released/modules/envinstance-kyma/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    btp = {
+      source = "SAP/btp"
+    }
+  }
+}

--- a/released/modules/envinstance-kyma/variables.tf
+++ b/released/modules/envinstance-kyma/variables.tf
@@ -1,0 +1,51 @@
+variable "subaccount_id" {
+  description = "The ID of the subaccount."
+  type        = string
+}
+
+variable "plan" {
+  description = "The kyma service plan to be used."
+  type        = string
+  default     = null
+}
+
+variable "name" {
+  description = "The name of the kyma cluster."
+  type        = string
+}
+
+variable "administrators" {
+  description = "Users to be assigned as administrators."
+  type        = set(string)
+  default     = []
+}
+
+variable "oidc" {
+  description = "Custom OpenID Connect IdP to authenticate users in your Kyma runtime."
+  type = object({
+    # the URL of the OpenID issuer (use the https schema)
+    issuer_url = string
+
+    # the client ID for the OpenID client
+    client_id = string
+
+    #the name of a custom OpenID Connect claim for specifying user groups
+    groups_claim = string
+
+    # the list of allowed cryptographic algorithms used for token signing. The allowed values are defined by RFC 7518.
+    signing_algs = set(string)
+
+    # the prefix for all usernames. If you don't provide it, username claims other than “email” are prefixed by the issuerURL to avoid clashes. To skip any prefixing, provide the value as -.
+    username_prefix = string
+
+    # the name of a custom OpenID Connect claim for specifying a username
+    username_claim = string
+  })
+  default = null
+}
+
+variable "region" {
+  description = "The region of the kyma environment"
+  type        = string
+  default     = "eu12"
+}


### PR DESCRIPTION
# Purpose

Adds a module to instantiate kyma clusters in a BTP account.


```hcl
module "k8s_runtime" {
  source = "github.com/SAP-samples/btp-terraform-samples/released/modules/envinstance-kyma"

  subaccount_id = btp_subaccount.kyma_gitops.id

  name          = "my-cluster"
  plan          = "trial"
}
```

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Other Information
<!-- Add any other helpful information that may be needed here. -->
