### PR TITLE
feat: bootstrap gitops enabled kyma with fluxcd in btp

### DIFF
--- a/released/uc_kyma_gitops_fluxcd/README.md
+++ b/released/uc_kyma_gitops_fluxcd/README.md
@@ -1,0 +1,54 @@
+# Terraform Workspace for Kyma GitOps
+
+This Terraform workspace creates a BTP subaccount and a Kubernetes cluster with Kyma runtime, and then bootstraps it with [Flux CD](https://flux.io) for GitOps. 
+
+## Structure
+
+The workspace contains the following files:
+
+- `main.tf`: Contains the resources and modules for creating the BTP subaccount, the Kyma runtime environment, and the Flux CD bootstrap.
+- `outputs.tf`: Defines the output values for the Kyma dashboard URL and the Kubeconfig of the Kyma runtime.
+- `provider.tf`: Specifies the required Terraform providers and their configurations.
+- `variables.tf`: Defines the variables used across the workspace.
+
+## Prerequisites
+
+- You need admin access to a [BTP trial account](https://account.hanatrial.ondemand.com/trial/#/home/trial).
+- You need to have [Terraform](https://developer.hashicorp.com/terraform/downloads) installed in your system.
+
+## Usage
+
+1. Create a new git repository to be used by flux  and fill it with the content you can find [here](https://github.com/SAP-samples/btp-terraform-samples/tree/kyma-gitops).
+
+2. Clone the repository:
+    ```
+    git clone https://github.com/SAP-samples/btp-terraform-samples.git
+    ```
+3. Navigate to the directory:
+    ```
+    cd released/uc_kyma_gitops_fluxcd
+    ```
+4. Initialize Terraform:
+    ```
+    terraform init
+    ```
+5. Apply the Terraform configuration:
+    ```
+    terraform apply
+    ```
+The `terraform apply` command will prompt you for the values of the following variables:
+- `globalaccount`: The subdomain of your trial account (e.g. `4605efebtrial-ga`)
+- `fluxcd_git_repository`: The URL of the Git repository to bootstrap flux from.
+- `fluxcd_git_username`: The username for basic authentication to the Git repository.
+- `fluxcd_git_password`: The password for basic authentication to the Git repository (can be a personal access token).
+
+## Outputs
+
+The workspace provides the following outputs:
+
+- `kyma_dashboard_url`: The URL of the Kyma dashboard.
+- `kyma_kubeconfig`: The Kubeconfig of the Kyma runtime.
+
+## Note
+
+The Flux CD bootstrap configures the Kyma runtime to reconcile its state from the `fluxcd_git_branch` of the `fluxcd_git_repository`. The namespace `flux-system` is labeled with `istio-injection=enabled`, which enables Istio sidecar injection for the Flux CD components.

--- a/released/uc_kyma_gitops_fluxcd/main.tf
+++ b/released/uc_kyma_gitops_fluxcd/main.tf
@@ -1,0 +1,43 @@
+resource "btp_subaccount" "kyma_gitops" {
+  name      = "kyma-gitops"
+  subdomain = "kyma-gitops"
+  region    = var.region
+}
+
+module "k8s_runtime" {
+  source = "github.com/SAP-samples/btp-terraform-samples/released/modules/envinstance-kyma"
+
+  subaccount_id = btp_subaccount.kyma_gitops.id
+
+  name           = var.cluster_name
+  administrators = var.developers
+  plan           = "trial"
+}
+
+resource "flux_bootstrap_git" "this" {
+  path = "clusters/${var.cluster_name}"
+
+  kustomization_override = local.kustomization
+
+  depends_on = [module.k8s_runtime]
+}
+
+locals {
+  kustomization = <<KUSTOMIZATION
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../base/flux-system/
+resources:
+- gotk-components.yaml
+- gotk-sync.yaml
+patches:
+- patch: |-
+    - op: add 
+      path: /metadata/labels/istio-injection
+      value: enabled
+  target:
+    kind: Namespace
+    name: flux-system
+KUSTOMIZATION
+}

--- a/released/uc_kyma_gitops_fluxcd/outputs.tf
+++ b/released/uc_kyma_gitops_fluxcd/outputs.tf
@@ -1,0 +1,7 @@
+output "kyma_dashboard_url" {
+  value = module.k8s_runtime.dashboard_url
+}
+
+output "kyma_kubeconfig" {
+  value = module.k8s_runtime.kubeconfig
+}

--- a/released/uc_kyma_gitops_fluxcd/provider.tf
+++ b/released/uc_kyma_gitops_fluxcd/provider.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_providers {
+    btp = {
+      source  = "SAP/btp"
+      version = "0.3.0-beta1"
+    }
+    flux = {
+      source  = "fluxcd/flux"
+      version = "1.0.1"
+    }
+  }
+}
+
+provider "btp" {
+  globalaccount = var.globalaccount
+}
+
+provider "flux" {
+  kubernetes = {
+    config_path = module.k8s_runtime.kubeconfig
+  }
+
+  git = {
+    url    = var.fluxcd_git_repository
+    branch = var.fluxcd_git_branch
+
+    http = {
+      username = var.fluxcd_git_username
+      password = var.fluxcd_git_password
+    }
+  }
+}

--- a/released/uc_kyma_gitops_fluxcd/variables.tf
+++ b/released/uc_kyma_gitops_fluxcd/variables.tf
@@ -1,0 +1,40 @@
+variable "globalaccount" {
+  description = "The subdomain of your trialaccount (e.g. '4605efebtrial-ga')"
+}
+
+variable "region" {
+  description = "The BTP region"
+  default     = "us10"
+}
+
+variable "developers" {
+  description = "All the developers working on the project"
+  default     = []
+}
+
+variable "cluster_name" {
+  type    = string
+  default = "kyma-gitops-showcase"
+}
+
+variable "fluxcd_git_repository" {
+  type        = string
+  description = "Url of git repository to bootstrap from"
+}
+
+variable "fluxcd_git_branch" {
+  type        = string
+  description = "Branch in repository to reconcile from"
+  default     = "main"
+}
+
+variable "fluxcd_git_username" {
+  type        = string
+  description = "Username for basic authentication"
+}
+
+variable "fluxcd_git_password" {
+  type        = string
+  description = " Password for basic authentication"
+  sensitive   = true
+}


### PR DESCRIPTION
# Purpose

Adding yet another usecase to demonstrate how a gitops enabled kyma environment can be bootstrapped in BTP. In this case [fluxcd](https://flux.io) is used as gitops operator.

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Other Information
<!-- Add any other helpful information that may be needed here. -->
