### PR TITLE
Use new convention for service plan variables, externalize service names as local variables

### DIFF
--- a/released/discovery_center/mission_4024/locals.tf
+++ b/released/discovery_center/mission_4024/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  service_name__sap_build_apps = "sap-build-apps"
+  service_name__build_workzone = "SAPLaunchpad"
+}

--- a/released/discovery_center/mission_4024/main.tf
+++ b/released/discovery_center/mission_4024/main.tf
@@ -66,27 +66,27 @@ resource "btp_subaccount_subscription" "identity_instance" {
 # Entitle subaccount for usage of app  destination SAP Build Workzone, standard edition
 resource "btp_subaccount_entitlement" "build_workzone" {
   subaccount_id = data.btp_subaccount.project.id
-  service_name  = "SAPLaunchpad"
-  plan_name     = var.build_workzone_service_plan
-  amount        = var.build_workzone_service_plan == "free" ? 1 : null
+  service_name  = local.service_name__build_workzone
+  plan_name     = var.service_plan__build_workzone
+  amount        = var.service_plan__build_workzone == "free" ? 1 : null
 }
  
 # Create app subscription to SAP Build Workzone, standard edition (depends on entitlement)
 resource "btp_subaccount_subscription" "build_workzone" {
   subaccount_id = data.btp_subaccount.project.id
-  app_name      = "SAPLaunchpad"
-  plan_name     = var.build_workzone_service_plan
+  app_name      = local.service_name__build_workzone
+  plan_name     = var.service_plan__build_workzone
   depends_on    = [btp_subaccount_entitlement.build_workzone]
 }
  
 ###############################################################################################
 # Prepare and setup app: SAP Build Apps
 ###############################################################################################
-# Entitle subaccount for usage of app  destination SAP Build Workzone, standard edition
+# Entitle subaccount for usage of SAP Build Apps
 resource "btp_subaccount_entitlement" "sap_build_apps" {
   subaccount_id = data.btp_subaccount.project.id
-  service_name  = "sap-build-apps"
-  plan_name     = var.sap_build_apps_service_plan
+  service_name  = local.service_name__sap_build_apps
+  plan_name     = var.service_plan__sap_build_apps
   amount = 1
   depends_on = [btp_subaccount_trust_configuration.fully_customized]
 }
@@ -95,7 +95,7 @@ resource "btp_subaccount_entitlement" "sap_build_apps" {
 resource "btp_subaccount_subscription" "sap-build-apps_standard" {
   subaccount_id = data.btp_subaccount.project.id
   app_name      = "sap-appgyver-ee"
-  plan_name     = var.sap_build_apps_service_plan
+  plan_name     = var.service_plan__sap_build_apps
   depends_on = [btp_subaccount_entitlement.sap_build_apps]
 }
  

--- a/released/discovery_center/mission_4024/variables.tf
+++ b/released/discovery_center/mission_4024/variables.tf
@@ -32,24 +32,24 @@ variable "region" {
   description = "The region where the sub account shall be created in."
   default     = "us10"
 }
- 
-variable "sap_build_apps_service_plan" {
+
+variable "service_plan__sap_build_apps" {
   type        = string
-  description = "The plan for sap_build_apps subscription"
+  description = "The plan for SAP Build Apps subscription"
   default     = "free"
   validation {
-    condition     = contains(["free", "standard", "partner"], var.sap_build_apps_service_plan)
-    error_message = "Invalid value for sap_build_apps_service_plan. Only 'free', 'standard' and 'partner' are allowed."
+    condition     = contains(["free", "standard", "partner"], var.service_plan__sap_build_apps)
+    error_message = "Invalid value for service_plan__sap_build_apps. Only 'free', 'standard' and 'partner' are allowed."
   }
 }
  
-variable "build_workzone_service_plan" {
+variable "service_plan__build_workzone" {
   type        = string
   description = "The plan for build_workzone subscription"
   default     = "free"
   validation {
-    condition     = contains(["free", "standard"], var.build_workzone_service_plan)
-    error_message = "Invalid value for build_workzone_service_plan. Only 'free' and 'standard' are allowed."
+    condition     = contains(["free", "standard"], var.service_plan__build_workzone)
+    error_message = "Invalid value for service_plan__build_workzone. Only 'free' and 'standard' are allowed."
   }
 }
  


### PR DESCRIPTION
# Purpose

* Make service (plan) variables more machine-readable, to allow pipeline for Quick-Account-Setup solutions to more easily infer what are the service plan inputs

## Pull Request Type

```
[ ] Bugfix
[ ] Feature
[ ] Documentation content changes
[x] Other... Please describe: change structure of variables to follow conventions for Quick-Account-Setup
```