### PR TITLE
fix: Add missing cli_server_url in provider.tf for mission 4024

### DIFF
--- a/released/discovery_center/mission_4024/provider.tf
+++ b/released/discovery_center/mission_4024/provider.tf
@@ -11,5 +11,6 @@ provider "btp" {
   # Comment out the idp in case you need it to connect to your global account
   # -------------------------------------------------------------------------
   # idp            = var.custom_idp
+  cli_server_url = var.cli_server_url
   globalaccount  = var.globalaccount
 }


### PR DESCRIPTION
# Purpose

`cli_server_url` is defined as a variable in variables.tf, but is not passed through to the provider and hence the default cannot be overwritten.

## Pull Request Type

```
[x] Bugfix
[ ] Feature
[ ] Documentation content changes
[ ] Other... Please describe:
```

