### PR TITLE
fix: Output sap_build_apps_subscription_url instead of sap_build_app_subscription_url, mission 4024

### DIFF
--- a/in-development/mission_4024_multi_step/1_main_config/outputs.tf
+++ b/in-development/mission_4024_multi_step/1_main_config/outputs.tf
@@ -3,7 +3,7 @@ output "subaccount_id" {
   description = "The ID of the project subaccount."
 }
 
-output "sap_build_app_subscription_url" {
+output "sap_build_apps_subscription_url" {
   value       = btp_subaccount_subscription.sap-build-apps_standard.subscription_url
-  description = "The subscription_url of build app."
+  description = "SAP Build Apps subscription URL."
 }

--- a/released/discovery_center/mission_4024/outputs.tf
+++ b/released/discovery_center/mission_4024/outputs.tf
@@ -3,7 +3,7 @@ output "subaccount_id" {
   description = "The ID of the project subaccount."
 }
 
-output "sap_build_app_subscription_url" {
+output "sap_build_apps_subscription_url" {
   value       = btp_subaccount_subscription.sap-build-apps_standard.subscription_url
-  description = "The subscription_url of build app."
+  description = "SAP Build Apps subscription URL."
 }


### PR DESCRIPTION
# Purpose
* Fixes the output of mission 4024 to read `sap_build_apps_subscription_url` instead of `sap_build_app_subscription_url`

## Pull Request Type

What kind of change does this Pull Request introduce?

```
[x] Bugfix
[ ] Feature
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Other Information

This is to a) align this with the product's actual name, b) make it consistent with the other occurrences in this repo and c) make the mission work for QAS. Plus a nicer description.
