### PR TITLE
Remove current user from CF org users/admins

### DIFF
--- a/released/discovery_center/mission_4327/step1/main.tf
+++ b/released/discovery_center/mission_4327/step1/main.tf
@@ -17,6 +17,7 @@ resource "btp_subaccount" "project" {
   subdomain = local.subaccount_domain
   region    = lower(var.region)
 }
+
 data "btp_whoami" "me" {}
 
 data "btp_subaccount_environments" "all" {
@@ -56,7 +57,7 @@ resource "btp_subaccount_environment_instance" "cloudfoundry" {
 # Assignment of users as sub account administrators
 ###############################################################################################
 resource "btp_subaccount_role_collection_assignment" "subaccount-admins" {
-  for_each             = toset("${var.subaccount_admins}")
+  for_each             = toset(var.subaccount_admins)
   subaccount_id        = btp_subaccount.project.id
   role_collection_name = "Subaccount Administrator"
   user_name            = each.value
@@ -136,14 +137,19 @@ resource "btp_subaccount_entitlement" "hana-hdi-shared" {
   plan_name     = "hdi-shared"
 }
 
+locals {
+  cf_org_users = setsubtract(toset(var.cf_org_users), [data.btp_whoami.me.email])
+  cf_org_admins = setsubtract(toset(var.cf_org_admins), [data.btp_whoami.me.email])
+}
+
 resource "local_file" "output_vars_step1" {
   count    = var.create_tfvars_file_for_next_stage ? 1 : 0
   content  = <<-EOT
       cf_api_url          = "${jsondecode(btp_subaccount_environment_instance.cloudfoundry.labels)["API Endpoint"]}"
       cf_org_id           = "${btp_subaccount_environment_instance.cloudfoundry.platform_id}"
 
-      cf_org_users        = ${jsonencode(var.cf_org_users)}
-      cf_org_admins       = ${jsonencode(var.cf_org_admins)}
+      cf_org_users        = ${jsonencode(local.cf_org_users)}
+      cf_org_admins       = ${jsonencode(local.cf_org_admins)}
       cf_space_developers = ${jsonencode(var.cf_space_developers)}
       cf_space_managers   = ${jsonencode(var.cf_space_managers)}
 

--- a/released/discovery_center/mission_4327/step1/main.tf
+++ b/released/discovery_center/mission_4327/step1/main.tf
@@ -138,7 +138,7 @@ resource "btp_subaccount_entitlement" "hana-hdi-shared" {
 }
 
 locals {
-  cf_org_users = setsubtract(toset(var.cf_org_users), [data.btp_whoami.me.email])
+  cf_org_users  = setsubtract(toset(var.cf_org_users), [data.btp_whoami.me.email])
   cf_org_admins = setsubtract(toset(var.cf_org_admins), [data.btp_whoami.me.email])
 }
 

--- a/released/discovery_center/mission_4327/step1/outputs.tf
+++ b/released/discovery_center/mission_4327/step1/outputs.tf
@@ -13,3 +13,11 @@ output "cf_org_id" {
 output "cf_api_url" {
   value = lookup(jsondecode(btp_subaccount_environment_instance.cloudfoundry.labels), "API Endpoint", "not found")
 }
+
+output "cf_org_users" {
+  value = local.cf_org_users
+}
+
+output "cf_org_admins" {
+  value = local.cf_org_admins
+}


### PR DESCRIPTION
# Purpose
* Mission 4327: Remove current user from CF org users/admins (required for QAS)

## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Documentation content changes
[x] Other... Please describe: QAS update for mission 4327
```

## Other Information
For QAS the current user might be in the list of CF org users and admins. This will lead to errors as the current user already has those roles and the API isn't idempotent.
