### PR TITLE
chore: version update of the providers

### DIFF
--- a/released/usecases/dev_test_prod_setup/modules/subaccount_setup/subaccount_setup.tf
+++ b/released/usecases/dev_test_prod_setup/modules/subaccount_setup/subaccount_setup.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "~> 1.5.0"
+      version = "~> 1.7.0"
     }
   }
 }

--- a/released/usecases/dev_test_prod_setup/provider.tf
+++ b/released/usecases/dev_test_prod_setup/provider.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     btp = {
       source  = "sap/btp"
-      version = "~> 1.5.0"
+      version = "~> 1.7.0"
     }
     cloudfoundry = {
-      source  = "cloudfoundry-community/cloudfoundry"
-      version = "0.53.1"
+      source  = "cloudfoundry/cloudfoundry"
+      version = "1.0.0"
     }
   }
 }


### PR DESCRIPTION
# Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Both BTP and CLOUDFOUNDRY terraform provider versions have been updated to latest (1.7.0 and 1.0.0) in dev_test_prod_setup usecase.
## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Documentation content changes
[x] Other... Please describe:
```

## Other Information
<!-- Add any other helpful information that may be needed here. -->
